### PR TITLE
feat(petstore): add `rdme` GitHub Action examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -8,8 +8,8 @@ name: 'Sync Petstore 🐶'
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
 
 jobs:
   sync:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,27 @@
+# This is an example workflow that syncs `petstore.json` to ReadMe via the `rdme` GitHub Action
+# Petstore docs on ReadMe: https://petstore.readme.io
+# `rdme` docs: https://docs.readme.com/docs/rdme
+name: 'Sync Petstore 🐶'
+
+# This workflow any time there is a push to the `main` branch
+# See GitHub's docs for all the possible event types:
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Check out repository # the `name` field is optional for steps
+
+      - uses: readmeio/rdme@7.0.1
+        name: Run sync command
+        with:
+          # See our docs for more examples on using GitHub Secrets:
+          # https://docs.readme.com/docs/rdme#example-using-github-secrets
+          rdme: openapi FILE --key=${{ secrets.PETSTORE_PROJECT_API_KEY }} --id=62069f4ed4ba76002b4dc07c

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -8,8 +8,8 @@ name: 'Sync Petstore 🐶'
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
 
 jobs:
   sync:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -24,4 +24,4 @@ jobs:
         with:
           # See our docs for more examples on using GitHub Secrets:
           # https://docs.readme.com/docs/rdme#example-using-github-secrets
-          rdme: openapi FILE --key=${{ secrets.PETSTORE_PROJECT_API_KEY }} --id=62069f4ed4ba76002b4dc07c
+          rdme: openapi 3.1/json/petstore.json --key=${{ secrets.PETSTORE_PROJECT_API_KEY }} --id=62069f4ed4ba76002b4dc07c

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,7 +1,7 @@
 # This is an example workflow that validates the `petstore` OpenAPI definitions via the `rdme` GitHub Action
 # Petstore docs on ReadMe: https://petstore.readme.io
 # `rdme` docs: https://docs.readme.com/docs/rdme
-name: 'Validate Petstore 🐶'
+name: 'Validate Petstore Files 🐶'
 
 # This workflow any time there is a push to the GitHub repository
 # See GitHub's docs for all the possible event types:
@@ -10,7 +10,6 @@ on: push
 
 jobs:
   validate:
-    name: Validate petstore files
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,50 @@
+# This is an example workflow that validates the `petstore` OpenAPI definitions via the `rdme` GitHub Action
+# Petstore docs on ReadMe: https://petstore.readme.io
+# `rdme` docs: https://docs.readme.com/docs/rdme
+name: 'Validate Petstore 🐶'
+
+# This workflow any time there is a push to the GitHub repository
+# See GitHub's docs for all the possible event types:
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+on: push
+
+jobs:
+  validate:
+    name: Validate petstore files
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Check out repository # the `name` field is optional for steps
+
+      - uses: readmeio/rdme@7.0.1
+        name: Validate 2.0 (json)
+        with:
+          # See our `rdme` docs for more GitHub Actions usage examples:
+          # https://docs.readme.com/docs/rdme
+          rdme: validate 2.0/json/petstore.json
+
+      - uses: readmeio/rdme@7.0.1
+        name: Validate 2.0 (yaml)
+        with:
+          rdme: validate 2.0/yaml/petstore.yaml
+
+      - uses: readmeio/rdme@7.0.1
+        name: Validate 3.0 (json)
+        with:
+          rdme: validate 3.0/json/petstore.json
+
+      - uses: readmeio/rdme@7.0.1
+        name: Validate 3.0 (yaml)
+        with:
+          rdme: validate 3.0/yaml/petstore.yaml
+
+      - uses: readmeio/rdme@7.0.1
+        name: Validate 3.1 (json)
+        with:
+          rdme: validate 3.1/json/petstore.json
+
+      - uses: readmeio/rdme@7.0.1
+        name: Validate 3.1 (yaml)
+        with:
+          rdme: validate 3.1/yaml/petstore.yaml


### PR DESCRIPTION
## 🧰 Changes

This adds a few example workflows for syncing and validating the petstore OpenAPI definitions.

## 🧬 QA & Testing

I confirmed that the sync command works in this workflow: https://github.com/readmeio/oas-examples/runs/5744217667

Do both workflows look good?