### PR TITLE
feat(3.0): add examples of certain http behaviors

### DIFF
--- a/3.0/json/response-http-behavior.json
+++ b/3.0/json/response-http-behavior.json
@@ -1,0 +1,96 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "This is a sample oas file to test unique HTTP behavior.",
+    "version": "1.0.0",
+    "title": "HTTP test",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://httpbin.org"
+    }
+  ],
+  "paths": {
+    "/cache": {
+      "get": {
+        "summary": "Load a file with caching headers",
+        "description": "Making this request without these parameters should make an uncached request. When you provide `if-modified-since` or `if-none-match` you should return a `304 Not Modified`",
+        "operationId": "cached",
+        "parameters": [
+          {
+            "name": "If-Modified-Since",
+            "in": "header",
+            "description": "An RFC 3339 formatted `date-time` string, preferably in UTC. If the resource was last updated before the provided `date-time`, the server should return a `304 Not Modified` response, otherwise a 200 with an accurate `last-modified` time",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "description": "If you provide a value here, it will be checked against the generated ETAG of the target resource. If they match, you'll get a `304 Not Modified` response, otherwise a `200 OK` with a new ETAG",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful response"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/status/302": {
+      "get": {
+        "summary": "Redirect",
+        "description": "Returns a `302 Found` status",
+        "operationId": "redirect",
+        "responses": {
+          "default": {
+            "description": "successful response"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/status/204": {
+      "get": {
+        "summary": "No content",
+        "description": "Returns a `204 No Content` with no body",
+        "operationId": "nocontent",
+        "responses": {
+          "default": {
+            "description": "successful response"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+  },
+  "x-readme": {
+    "proxy-enabled": false
+  }
+}

--- a/3.0/json/response-http-behavior.json
+++ b/3.0/json/response-http-behavior.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "description": "This is a sample oas file to test unique HTTP behavior.",
+    "description": "This is a sample definition to test unique HTTP behavior.",
     "version": "1.0.0",
     "title": "HTTP test",
     "license": {
@@ -18,13 +18,13 @@
     "/cache": {
       "get": {
         "summary": "Load a file with caching headers",
-        "description": "Making this request without these parameters should make an uncached request. When you provide `if-modified-since` or `if-none-match` you should return a `304 Not Modified`",
+        "description": "Making this request without these parameters should make an uncached request. When you provide `if-modified-since` or `if-none-match` you should return a `304 Not Modified`.",
         "operationId": "cached",
         "parameters": [
           {
             "name": "If-Modified-Since",
             "in": "header",
-            "description": "An RFC 3339 formatted `date-time` string, preferably in UTC. If the resource was last updated before the provided `date-time`, the server should return a `304 Not Modified` response, otherwise a 200 with an accurate `last-modified` time",
+            "description": "An RFC 3339 formatted `date-time` string, preferably in UTC. If the resource was last updated before the provided `date-time`, the server should return a `304 Not Modified` response, otherwise a 200 with an accurate `last-modified` time.",
             "required": false,
             "schema": {
               "type": "string",
@@ -34,7 +34,7 @@
           {
             "name": "If-None-Match",
             "in": "header",
-            "description": "If you provide a value here, it will be checked against the generated ETAG of the target resource. If they match, you'll get a `304 Not Modified` response, otherwise a `200 OK` with a new ETAG",
+            "description": "If you provide a value here, it will be checked against the generated ETAG of the target resource. If they match, you'll get a `304 Not Modified` response, otherwise a `200 OK` with a new ETAG.",
             "required": false,
             "schema": {
               "type": "string"
@@ -87,8 +87,6 @@
         ]
       }
     }
-  },
-  "components": {
   },
   "x-readme": {
     "proxy-enabled": false

--- a/3.0/yaml/response-http-behavior.yaml
+++ b/3.0/yaml/response-http-behavior.yaml
@@ -1,47 +1,46 @@
----
 openapi: 3.0.0
 info:
-  description: This is a sample oas file to test unique HTTP behavior.
+  description: This is a sample definition to test unique HTTP behavior.
   version: 1.0.0
   title: HTTP test
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
-- url: http://httpbin.org
+  - url: http://httpbin.org
 paths:
-  "/cache":
+  '/cache':
     get:
       summary: Load a file with caching headers
       description: Making this request without these parameters should make an uncached
         request. When you provide `if-modified-since` or `if-none-match` you should
-        return a `304 Not Modified`
+        return a `304 Not Modified`.
       operationId: cached
       parameters:
-      - name: If-Modified-Since
-        in: header
-        description: An RFC 3339 formatted `date-time` string, preferably in UTC.
-          If the resource was last updated before the provided `date-time`, the server
-          should return a `304 Not Modified` response, otherwise a 200 with an accurate
-          `last-modified` time
-        required: false
-        schema:
-          type: string
-          format: date-time
-      - name: If-None-Match
-        in: header
-        description: If you provide a value here, it will be checked against the generated
-          ETAG of the target resource. If they match, you'll get a `304 Not Modified`
-          response, otherwise a `200 OK` with a new ETAG
-        required: false
-        schema:
-          type: string
+        - name: If-Modified-Since
+          in: header
+          description: An RFC 3339 formatted `date-time` string, preferably in UTC.
+            If the resource was last updated before the provided `date-time`, the server
+            should return a `304 Not Modified` response, otherwise a 200 with an accurate
+            `last-modified` time.
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: If-None-Match
+          in: header
+          description: If you provide a value here, it will be checked against the generated
+            ETAG of the target resource. If they match, you'll get a `304 Not Modified`
+            response, otherwise a `200 OK` with a new ETAG.
+          required: false
+          schema:
+            type: string
       responses:
         default:
           description: successful response
       security:
-      - api_key: []
-  "/status/302":
+        - api_key: []
+  '/status/302':
     get:
       summary: Redirect
       description: Returns a `302 Found` status
@@ -50,8 +49,8 @@ paths:
         default:
           description: successful response
       security:
-      - api_key: []
-  "/status/204":
+        - api_key: []
+  '/status/204':
     get:
       summary: No content
       description: Returns a `204 No Content` with no body
@@ -60,7 +59,6 @@ paths:
         default:
           description: successful response
       security:
-      - api_key: []
-components: {}
+        - api_key: []
 x-readme:
   proxy-enabled: false

--- a/3.0/yaml/response-http-behavior.yaml
+++ b/3.0/yaml/response-http-behavior.yaml
@@ -1,0 +1,66 @@
+---
+openapi: 3.0.0
+info:
+  description: This is a sample oas file to test unique HTTP behavior.
+  version: 1.0.0
+  title: HTTP test
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+- url: http://httpbin.org
+paths:
+  "/cache":
+    get:
+      summary: Load a file with caching headers
+      description: Making this request without these parameters should make an uncached
+        request. When you provide `if-modified-since` or `if-none-match` you should
+        return a `304 Not Modified`
+      operationId: cached
+      parameters:
+      - name: If-Modified-Since
+        in: header
+        description: An RFC 3339 formatted `date-time` string, preferably in UTC.
+          If the resource was last updated before the provided `date-time`, the server
+          should return a `304 Not Modified` response, otherwise a 200 with an accurate
+          `last-modified` time
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: If-None-Match
+        in: header
+        description: If you provide a value here, it will be checked against the generated
+          ETAG of the target resource. If they match, you'll get a `304 Not Modified`
+          response, otherwise a `200 OK` with a new ETAG
+        required: false
+        schema:
+          type: string
+      responses:
+        default:
+          description: successful response
+      security:
+      - api_key: []
+  "/status/302":
+    get:
+      summary: Redirect
+      description: Returns a `302 Found` status
+      operationId: redirect
+      responses:
+        default:
+          description: successful response
+      security:
+      - api_key: []
+  "/status/204":
+    get:
+      summary: No content
+      description: Returns a `204 No Content` with no body
+      operationId: nocontent
+      responses:
+        default:
+          description: successful response
+      security:
+      - api_key: []
+components: {}
+x-readme:
+  proxy-enabled: false


### PR DESCRIPTION
| 🚥 Fix RM-XXX |
| :-- |

## 🧰 Changes

While testing issues with caching headers and redirects I found this useful

