### PR TITLE
refactor: add tags to webhooks

### DIFF
--- a/3.1/json/webhooks.json
+++ b/3.1/json/webhooks.json
@@ -21,7 +21,8 @@
           "200": {
             "description": "Return a 200 status to indicate that the data was received successfully"
           }
-        }
+        },
+        "tags": ["Webhooks"]
       }
     }
   },

--- a/3.1/yaml/webhooks.yaml
+++ b/3.1/yaml/webhooks.yaml
@@ -15,6 +15,8 @@ webhooks:
         '200':
           description: Return a 200 status to indicate that the data was received
             successfully
+      tags:
+        - Webhooks
 components:
   schemas:
     Pet:


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes
Adding a `tags` object to the webhooks file. I'm updating the `getTags` function in the `oas` library and need to reference a file that has webhooks along with tags so I can correctly test the function.


## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
