### PR TITLE
feat: more examples for request/response pairs

### DIFF
--- a/3.0/json/readme-extensions.json
+++ b/3.0/json/readme-extensions.json
@@ -43,6 +43,32 @@
         "summary": "Custom code samples with the \"x-readme.code-samples\" extension",
         "description": "This is a demonstration of our handling of our `x-readme.code-samples` extension.\n\nhttps://docs.readme.com/docs/openapi-extensions#custom-code-samples",
         "tags": ["Custom code samples"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Tag"
+              },
+              "examples": {
+                "userRegistration": {
+                  "value": {
+                    "id": 1234,
+                    "email": "test@example.com",
+                    "name": "Test user name"
+                  }
+                },
+                "userRegistration alt": {
+                  "value": {
+                    "id": 5678,
+                    "email": "test@example.com",
+                    "name": "Test user name"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -62,6 +88,21 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "curlExample": {
+                    "summary": "An example of a cat",
+                    "value": {
+                      "missing": "can't find your stuff dawg"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "x-readme": {
@@ -76,15 +117,37 @@
             {
               "name": "Another cURL snippet",
               "language": "curl",
-              "code": "curl -X POST https://api.example.com/v2/another-alert",
-              "install": "brew install curl"
+              "code": "http POST https://api.example.com/v2/another-alert",
+              "install": "brew install httpie",
+              "correspondingExample": "curlExample"
             },
             {
               "language": "curl",
               "code": "# This custom cURL snippet does not have a custom name so it has the name of \"Default #2\".\n\ncurl -X POST https://api.example.com/v2/alert"
+            },
+            {
+              "name": "Yet another custom snippet",
+              "language": "curl",
+              "code": "curl -X POST https://api.example.com/v2/alert",
+              "install": "brew install curl",
+              "correspondingExample": "TestExample"
+            },
+            {
+              "name": "Yet another custom snippet",
+              "language": "python",
+              "code": "import requests\n\nprint(\"do something idk\")",
+              "install": "pip install requests",
+              "correspondingExample": "TestExample"
+            },
+            {
+              "name": "Yet another custom snippet",
+              "language": "node",
+              "code": "import something from 'requestidk';\n\nconsole.log('do something idk');",
+              "install": "npm install requestidk",
+              "correspondingExample": "curlExample"
             }
           ],
-          "samples-languages": ["shell"]
+          "samples-languages": ["shell", "python", "node"]
         }
       },
       "get": {

--- a/3.0/json/readme-extensions.json
+++ b/3.0/json/readme-extensions.json
@@ -45,7 +45,23 @@
         "tags": ["Custom code samples"],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "TestExample": {
+                    "summary": "An example of a cat",
+                    "value": {
+                      "name": "Fluffy",
+                      "petType": "Cat",
+                      "color": "White",
+                      "gender": "male",
+                      "breed": "Persian"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "x-readme": {
@@ -54,13 +70,21 @@
               "name": "Custom cURL snippet",
               "language": "curl",
               "code": "curl -X POST https://api.example.com/v2/alert",
+              "install": "brew install curl",
+              "correspondingExample": "TestExample"
+            },
+            {
+              "name": "Another cURL snippet",
+              "language": "curl",
+              "code": "curl -X POST https://api.example.com/v2/another-alert",
               "install": "brew install curl"
             },
             {
               "language": "curl",
               "code": "# This custom cURL snippet does not have a custom name so it has the name of \"Default #2\".\n\ncurl -X POST https://api.example.com/v2/alert"
             }
-          ]
+          ],
+          "samples-languages": ["shell"]
         }
       },
       "get": {

--- a/3.0/json/request-examples.json
+++ b/3.0/json/request-examples.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "Support for request body examples",
+    "title": "Support for request body and parameter examples",
     "description": "https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#requestBodyObject",
     "version": "1.0.0"
   },
@@ -22,11 +22,147 @@
     }
   ],
   "paths": {
-    "/requestBody": {
-      "post": {
+    "/parameterExamples/{param1}/{param2}": {
+      "get": {
         "tags": ["Multiple examples"],
-        "summary": "Within `examples`",
-        "description": "This operation has a `requestBody` with separately maintained example within `examples` at the Media Type Object level.\n\n📚 OpenAPI specification references:\n\n* [3.0.3 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject)\n\n* [3.1.0 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject)",
+        "summary": "Within `examples` (parameters)",
+        "description": "This operation has several parameters with examples alongside separately maintained example within `examples` at the Media Type Object level.\n\n📚 OpenAPI specification references:\n\n* [3.0.3 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject)\n\n* [3.1.0 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject)",
+        "parameters": [
+          {
+            "name": "param1",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "userRegistration": {
+                "summary": "example summary (param 1)",
+                "description": "a lengthier example description (param 1)",
+                "value": "param1-example"
+              },
+              "yetAnotherParamExample": {
+                "value": "param1-example-again"
+              }
+            }
+          },
+          {
+            "name": "param2",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "userRegistration": {
+                "summary": "example summary (param 2)",
+                "description": "a lengthier example description (param 2)",
+                "value": "param2-example"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user"
+                },
+                "examples": {
+                  "userRegistration": {
+                    "value": {
+                      "summary": "example summary (response)",
+                      "description": "a lengthier example description (response)",
+                      "id": 1234,
+                      "email": "test+response@example.com",
+                      "name": "Test user name (response)"
+                    }
+                  },
+                  "response": {
+                    "value": {
+                      "id": 1234,
+                      "email": "test@example.com",
+                      "name": "Test user name"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/xml": {
+                "examples": {
+                  "response": {
+                    "value": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><body>Invalid user!</body></note>"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user"
+                },
+                "examples": {
+                  "response": {
+                    "value": {
+                      "id": 1234,
+                      "email": "test@example.com",
+                      "name": "Test user name"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": ["Multiple examples"],
+        "summary": "Within `examples` (mixed)",
+        "description": "This operation has parameter and body examples alongside separately maintained example within `examples` at the Media Type Object level.\n\n📚 OpenAPI specification references:\n\n* [3.0.3 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject)\n\n* [3.1.0 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject)",
+        "parameters": [
+          {
+            "name": "param1",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "userRegistration": {
+                "summary": "example summary (param 1)",
+                "description": "a lengthier example description (param 1)",
+                "value": "param1-example"
+              },
+              "yetAnotherParamExample": {
+                "value": "param1-example-again"
+              }
+            }
+          },
+          {
+            "name": "param2",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "userRegistration": {
+                "summary": "example summary (param 2)",
+                "description": "a lengthier example description (param 2)",
+                "value": "param2-example"
+              }
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -62,6 +198,166 @@
                   "$ref": "#/components/schemas/user"
                 },
                 "examples": {
+                  "userRegistration": {
+                    "value": {
+                      "summary": "example summary (response)",
+                      "description": "a lengthier example description (response)",
+                      "id": 1234,
+                      "email": "test+response@example.com",
+                      "name": "Test user name (response)"
+                    }
+                  },
+                  "response": {
+                    "value": {
+                      "id": 1234,
+                      "email": "test@example.com",
+                      "name": "Test user name"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/xml": {
+                "examples": {
+                  "response": {
+                    "value": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><body>Invalid user!</body></note>"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user"
+                },
+                "examples": {
+                  "response": {
+                    "value": {
+                      "id": 1234,
+                      "email": "test@example.com",
+                      "name": "Test user name"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["Single example"],
+        "summary": "Within `example`",
+        "description": "This operation has a param example and `requestBody` with separately maintained example within a simple `example` object at the Media Type Object level.\n\n📚 OpenAPI specification references:\n\n* [3.0.3 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject)\n\n* [3.1.0 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject)",
+        "parameters": [
+          {
+            "name": "param1",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "param1-example"
+          },
+          {
+            "name": "param2",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "param2-example"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/user"
+              },
+              "example": {
+                "id": 12343354,
+                "email": "test@example.com",
+                "name": "Test user name"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user"
+                },
+                "example": {
+                  "id": 12343354,
+                  "email": "test@example.com",
+                  "name": "Test user name"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/requestBody": {
+      "post": {
+        "tags": ["Multiple examples"],
+        "summary": "Within `examples` (body)",
+        "description": "This operation has a `requestBody` with separately maintained examples within `examples` at the Media Type Object level.\n\n📚 OpenAPI specification references:\n\n* [3.0.3 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject)\n\n* [3.1.0 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/user"
+              },
+              "examples": {
+                "userRegistration": {
+                  "value": {
+                    "id": 1234,
+                    "email": "test@example.com",
+                    "name": "Test user name"
+                  }
+                },
+                "userRegistration alt": {
+                  "value": {
+                    "id": 5678,
+                    "email": "test@example.com",
+                    "name": "Test user name"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user"
+                },
+                "examples": {
+                  "userRegistration": {
+                    "summary": "example summary (response)",
+                    "description": "a lengthier example description (response)",
+                    "value": {
+                      "id": 1234,
+                      "email": "test+response@example.com",
+                      "name": "Test user name (response)"
+                    }
+                  },
                   "response": {
                     "value": {
                       "id": 1234,

--- a/3.0/yaml/readme-extensions.yaml
+++ b/3.0/yaml/readme-extensions.yaml
@@ -29,20 +29,88 @@ paths:
         https://docs.readme.com/docs/openapi-extensions#custom-code-samples
       tags:
         - Custom code samples
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              '$ref': '#/components/schemas/Tag'
+            examples:
+              userRegistration:
+                value:
+                  id: 1234
+                  email: test@example.com
+                  name: Test user name
+              userRegistration alt:
+                value:
+                  id: 5678
+                  email: test@example.com
+                  name: Test user name
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              examples:
+                TestExample:
+                  summary: An example of a cat
+                  value:
+                    name: Fluffy
+                    petType: Cat
+                    color: White
+                    gender: male
+                    breed: Persian
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              examples:
+                curlExample:
+                  summary: An example of a cat
+                  value:
+                    missing: can't find your stuff dawg
       x-readme:
         code-samples:
           - name: Custom cURL snippet
             language: curl
             code: curl -X POST https://api.example.com/v2/alert
             install: brew install curl
+            correspondingExample: TestExample
+          - name: Another cURL snippet
+            language: curl
+            code: http POST https://api.example.com/v2/another-alert
+            install: brew install httpie
+            correspondingExample: curlExample
           - language: curl
             code: |-
               # This custom cURL snippet does not have a custom name so it has the name of "Default #2".
 
               curl -X POST https://api.example.com/v2/alert
+          - name: Yet another custom snippet
+            language: curl
+            code: curl -X POST https://api.example.com/v2/alert
+            install: brew install curl
+            correspondingExample: TestExample
+          - name: Yet another custom snippet
+            language: python
+            code: |-
+              import requests
+
+              print("do something idk")
+            install: pip install requests
+            correspondingExample: TestExample
+          - name: Yet another custom snippet
+            language: node
+            code: |-
+              import something from 'requestidk';
+
+              console.log('do something idk');
+            install: npm install requestidk
+            correspondingExample: curlExample
+        samples-languages:
+          - shell
+          - python
+          - node
     get:
       operationId: x-code-samples
       summary: Custom code samples with the "x-code-samples" extension

--- a/3.0/yaml/request-examples.yaml
+++ b/3.0/yaml/request-examples.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Support for request body examples
+  title: Support for request body and parameter examples
   description: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#requestBodyObject
   version: 1.0.0
 servers:
@@ -10,13 +10,216 @@ tags:
   - name: Single example
   - name: Multiple media types
 paths:
+  '/parameterExamples/{param1}/{param2}':
+    get:
+      tags:
+        - Multiple examples
+      summary: Within `examples` (parameters)
+      description: "This operation has several parameters with examples alongside
+        separately maintained example within `examples` at the Media Type Object level.\n\n\U0001F4DA
+        OpenAPI specification references:\n\n* [3.0.3 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject)\n\n*
+        [3.1.0 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject)"
+      parameters:
+        - name: param1
+          in: path
+          required: true
+          schema:
+            type: string
+          examples:
+            userRegistration:
+              summary: example summary (param 1)
+              description: a lengthier example description (param 1)
+              value: param1-example
+            yetAnotherParamExample:
+              value: param1-example-again
+        - name: param2
+          in: path
+          required: true
+          schema:
+            type: string
+          examples:
+            userRegistration:
+              summary: example summary (param 2)
+              description: a lengthier example description (param 2)
+              value: param2-example
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                '$ref': '#/components/schemas/user'
+              examples:
+                userRegistration:
+                  value:
+                    summary: example summary (response)
+                    description: a lengthier example description (response)
+                    id: 1234
+                    email: test+response@example.com
+                    name: Test user name (response)
+                response:
+                  value:
+                    id: 1234
+                    email: test@example.com
+                    name: Test user name
+        '400':
+          description: Validation failed
+          content:
+            application/xml:
+              examples:
+                response:
+                  value: <?xml version="1.0" encoding="UTF-8"?><note><body>Invalid
+                    user!</body></note>
+        default:
+          description: OK
+          content:
+            application/json:
+              schema:
+                '$ref': '#/components/schemas/user'
+              examples:
+                response:
+                  value:
+                    id: 1234
+                    email: test@example.com
+                    name: Test user name
+    patch:
+      tags:
+        - Multiple examples
+      summary: Within `examples` (mixed)
+      description: "This operation has parameter and body examples alongside separately
+        maintained example within `examples` at the Media Type Object level.\n\n\U0001F4DA
+        OpenAPI specification references:\n\n* [3.0.3 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject)\n\n*
+        [3.1.0 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject)"
+      parameters:
+        - name: param1
+          in: path
+          required: true
+          schema:
+            type: string
+          examples:
+            userRegistration:
+              summary: example summary (param 1)
+              description: a lengthier example description (param 1)
+              value: param1-example
+            yetAnotherParamExample:
+              value: param1-example-again
+        - name: param2
+          in: path
+          required: true
+          schema:
+            type: string
+          examples:
+            userRegistration:
+              summary: example summary (param 2)
+              description: a lengthier example description (param 2)
+              value: param2-example
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              '$ref': '#/components/schemas/user'
+            examples:
+              userRegistration:
+                value:
+                  id: 1234
+                  email: test@example.com
+                  name: Test user name
+              userRegistration alt:
+                value:
+                  id: 5678
+                  email: test@example.com
+                  name: Test user name
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                '$ref': '#/components/schemas/user'
+              examples:
+                userRegistration:
+                  value:
+                    summary: example summary (response)
+                    description: a lengthier example description (response)
+                    id: 1234
+                    email: test+response@example.com
+                    name: Test user name (response)
+                response:
+                  value:
+                    id: 1234
+                    email: test@example.com
+                    name: Test user name
+        '400':
+          description: Validation failed
+          content:
+            application/xml:
+              examples:
+                response:
+                  value: <?xml version="1.0" encoding="UTF-8"?><note><body>Invalid
+                    user!</body></note>
+        default:
+          description: OK
+          content:
+            application/json:
+              schema:
+                '$ref': '#/components/schemas/user'
+              examples:
+                response:
+                  value:
+                    id: 1234
+                    email: test@example.com
+                    name: Test user name
+    put:
+      tags:
+        - Single example
+      summary: Within `example`
+      description: "This operation has a param example and `requestBody` with separately
+        maintained example within a simple `example` object at the Media Type Object
+        level.\n\n\U0001F4DA OpenAPI specification references:\n\n* [3.0.3 Media Type
+        Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject)\n\n*
+        [3.1.0 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject)"
+      parameters:
+        - name: param1
+          in: path
+          required: true
+          schema:
+            type: string
+          example: param1-example
+        - name: param2
+          in: path
+          required: true
+          schema:
+            type: string
+          example: param2-example
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              '$ref': '#/components/schemas/user'
+            example:
+              id: 12343354
+              email: test@example.com
+              name: Test user name
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                '$ref': '#/components/schemas/user'
+              example:
+                id: 12343354
+                email: test@example.com
+                name: Test user name
   '/requestBody':
     post:
       tags:
         - Multiple examples
-      summary: Within `examples`
+      summary: Within `examples` (body)
       description: "This operation has a `requestBody` with separately maintained
-        example within `examples` at the Media Type Object level.\n\n\U0001F4DA OpenAPI
+        examples within `examples` at the Media Type Object level.\n\n\U0001F4DA OpenAPI
         specification references:\n\n* [3.0.3 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject)\n\n*
         [3.1.0 Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject)"
       requestBody:
@@ -44,6 +247,13 @@ paths:
               schema:
                 '$ref': '#/components/schemas/user'
               examples:
+                userRegistration:
+                  summary: example summary (response)
+                  description: a lengthier example description (response)
+                  value:
+                    id: 1234
+                    email: test+response@example.com
+                    name: Test user name (response)
                 response:
                   value:
                     id: 1234


### PR DESCRIPTION
## 🧰 Changes

Enhancing a couple existing definitions (`3.0/json/readme-extensions.json`, `3.0/json/request-examples.json`) so we have a variety of test cases for request/response example pair support.

## 🧬 QA & Testing

Do these examples validate and seem sound? I synced them to this test project if you want to give them a whirl:

https://kanad-rdme.readme.io/reference/x-readme_code-samples
https://kanad-rdme.readme.io/reference/get_parameterexamples-param1-param2