### PR TITLE
feat: add discriminator example from redocly

### DIFF
--- a/3.0/json/discriminators.json
+++ b/3.0/json/discriminators.json
@@ -305,6 +305,38 @@
         }
       }
     },
+    "/redocly-discriminator-madness": {
+      "patch": {
+        "operationId": "redoclyQuirk",
+        "summary": "Discriminator without `anyOf` or `oneOf` that Redocly supports",
+        "description": "Redocly allows users to define [a discriminator mapping without an `anyOf` or `oneOf` that contains the discriminated objects](https://redocly.com/docs/resources/discriminator#allof-for-inheritance). This endpoint demonstrates that.",
+        "tags": ["Quirks"],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "vehicle": {
+                    "$ref": "#/components/schemas/BaseVehicle"
+                  },
+                  "some_other_property": {
+                    "type": "string",
+                    "description": "Some other property that should render alongside the discriminated property",
+                    "default": "default-value"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/potentially-undefined-formData": {
       "post": {
         "summary": "Handling for potentially undefined formData",
@@ -626,6 +658,111 @@
           }
         },
         "required": ["event_type", "event_id"]
+      },
+      "BaseVehicle": {
+        "type": "object",
+        "description": "Vehicle (from [Redocly example](https://redocly.com/docs/resources/discriminator#when-to-use-the-openapi-discriminator))",
+        "discriminator": {
+          "propertyName": "powerSource",
+          "mapping": {
+            "electricity": "#/components/schemas/ElectricVehicle",
+            "gasoline": "#/components/schemas/FueledVehicle",
+            "human-energy": "#/components/schemas/PedaledVehicle"
+          }
+        },
+        "properties": {
+          "vehicleType": {
+            "description": "The type of vehicle.",
+            "type": "string",
+            "example": "bicycle"
+          },
+          "idealTerrain": {
+            "description": "A road, river, air... Where does this vehicle thrive?",
+            "type": "string",
+            "example": "roads"
+          },
+          "powerSource": {
+            "description": "How is the vehicle powered.",
+            "type": "string",
+            "example": "pedaling"
+          },
+          "topSpeed": {
+            "description": "The top speed in kilometers per hour rounded to the nearest integer.",
+            "type": "integer",
+            "example": 83
+          },
+          "range": {
+            "description": "The 95th percentile range of a trip in kilometers.",
+            "type": "integer",
+            "example": 100
+          }
+        }
+      },
+      "ElectricVehicle": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseVehicle"
+          },
+          {
+            "type": "object",
+            "description": "Electric Vehicle",
+            "properties": {
+              "chargeSpeed": {
+                "description": "In range kilometers per hour.",
+                "type": "integer"
+              },
+              "chargeAmps": {
+                "description": "Amps recommended for charging.",
+                "type": "integer"
+              },
+              "chargeVoltage": {
+                "description": "Voltage recommended for charging.",
+                "type": "integer"
+              }
+            }
+          }
+        ]
+      },
+      "FueledVehicle": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseVehicle"
+          },
+          {
+            "type": "object",
+            "title": "Gas-powered Vehicle",
+            "properties": {
+              "tankCapacity": {
+                "type": "number",
+                "format": "double",
+                "description": "Capacity of the fuel tank in gallons."
+              },
+              "milesPerGallon": {
+                "type": "number",
+                "format": "double",
+                "description": "Miles per gallon on the highway."
+              }
+            }
+          }
+        ]
+      },
+      "PedaledVehicle": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseVehicle"
+          },
+          {
+            "type": "object",
+            "description": "Pedaled Vehicle",
+            "properties": {
+              "handlebars": {
+                "type": "string",
+                "description": "Type of handlebars",
+                "enum": ["flat", "riser", "bullhorn", "drop", "aero", "cruiser"]
+              }
+            }
+          }
+        ]
       }
     }
   }

--- a/3.0/json/discriminators.json
+++ b/3.0/json/discriminators.json
@@ -305,7 +305,7 @@
         }
       }
     },
-    "/redocly-discriminator-madness": {
+    "/redocly-flavored-discriminator": {
       "patch": {
         "operationId": "redoclyQuirk",
         "summary": "Discriminator without `anyOf` or `oneOf` that Redocly supports",

--- a/3.0/yaml/discriminators.yaml
+++ b/3.0/yaml/discriminators.yaml
@@ -189,7 +189,7 @@ paths:
       responses:
         '200':
           description: OK
-  '/redocly-discriminator-madness':
+  '/redocly-flavored-discriminator':
     patch:
       operationId: redoclyQuirk
       summary: Discriminator without `anyOf` or `oneOf` that Redocly supports

--- a/3.0/yaml/discriminators.yaml
+++ b/3.0/yaml/discriminators.yaml
@@ -189,6 +189,28 @@ paths:
       responses:
         '200':
           description: OK
+  '/redocly-discriminator-madness':
+    patch:
+      operationId: redoclyQuirk
+      summary: Discriminator without `anyOf` or `oneOf` that Redocly supports
+      description: Redocly allows users to define [a discriminator mapping without an `anyOf` or `oneOf` that contains the discriminated objects](https://redocly.com/docs/resources/discriminator#allof-for-inheritance). This endpoint demonstrates that.
+      tags:
+        - Quirks
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                vehicle:
+                  $ref: '#/components/schemas/BaseVehicle'
+                some_other_property:
+                  type: string
+                  description: Some other property that should render alongside the discriminated property
+                  default: 'default-value'
+      responses:
+        '200':
+          description: OK
   '/potentially-undefined-formData':
     post:
       summary: Handling for potentially undefined formData
@@ -402,3 +424,78 @@ components:
       required:
         - event_type
         - event_id
+    BaseVehicle:
+      type: object
+      description: Vehicle (from [Redocly example](https://redocly.com/docs/resources/discriminator#when-to-use-the-openapi-discriminator))
+      discriminator:
+        propertyName: powerSource
+        mapping:
+          electricity: '#/components/schemas/ElectricVehicle'
+          gasoline: '#/components/schemas/FueledVehicle'
+          human-energy: '#/components/schemas/PedaledVehicle'
+      properties:
+        vehicleType:
+          description: The type of vehicle.
+          type: string
+          example: bicycle
+        idealTerrain:
+          description: A road, river, air... Where does this vehicle thrive?
+          type: string
+          example: roads
+        powerSource:
+          description: How is the vehicle powered.
+          type: string
+          example: pedaling
+        topSpeed:
+          description: The top speed in kilometers per hour rounded to the nearest integer.
+          type: integer
+          example: 83
+        range:
+          description: The 95th percentile range of a trip in kilometers.
+          type: integer
+          example: 100
+    ElectricVehicle:
+      allOf:
+        - $ref: '#/components/schemas/BaseVehicle'
+        - type: object
+          description: Electric Vehicle
+          properties:
+            chargeSpeed:
+              description: In range kilometers per hour.
+              type: integer
+            chargeAmps:
+              description: Amps recommended for charging.
+              type: integer
+            chargeVoltage:
+              description: Voltage recommended for charging.
+              type: integer
+    FueledVehicle:
+      allOf:
+        - $ref: '#/components/schemas/BaseVehicle'
+        - type: object
+          title: Gas-powered Vehicle
+          properties:
+            tankCapacity:
+              type: number
+              format: double
+              description: Capacity of the fuel tank in gallons.
+            milesPerGallon:
+              type: number
+              format: double
+              description: Miles per gallon on the highway.
+    PedaledVehicle:
+      allOf:
+        - $ref: '#/components/schemas/BaseVehicle'
+        - type: object
+          description: Pedaled Vehicle
+          properties:
+            handlebars:
+              type: string
+              description: Type of handlebars
+              enum:
+                - flat
+                - riser
+                - bullhorn
+                - drop
+                - aero
+                - cruiser


### PR DESCRIPTION
## 🧰 Changes

Redocly supports the usage of discriminator mappings that don't use `anyOf` or `oneOf` to explicitly define the objects 😵‍💫 this seems like [a divergence from the OpenAPI specification](https://spec.openapis.org/oas/v3.1.0#fixed-fields-20) (even Swagger UI doesn't support this):

> In both the `oneOf` and `anyOf` use cases, all possible schemas _MUST_ be listed explicitly.

... but this is a paradigm that users are expecting us to support ([more context here](https://linear.app/readme-io/issue/RM-10631/potential-oneof-discriminator-issue#comment-1868087b)). This PR adds an example of this kind of setup.

## 🧬 QA & Testing

Confirmed this is valid locally per `rdme`! And that it renders in both Redocly and ReadMe as I would expect.

For posterity, here's the new endpoint on our bin site: https://bin.readme.com/s/66ce3b9b46829b006ee0cee6